### PR TITLE
docs: list Juno in the deployment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Visit [http://localhost:3000](http://localhost:3000) to see your application in 
 
 ## Deployment
 
-Deploy your application with ease using platforms like Vercel, which provide out-of-the-box support for Next.js applications. Refer to platform-specific guides for details on deploying Next.js applications.
+Deploy your application with ease using platforms like [Vercel](https://vercel.com/), which provides out-of-the-box support for Next.js applications, or [Juno](https://juno.build), which gives you full control over your dApp by enabling its deployment on Web3. Refer to platform-specific guides for details on deploying Next.js applications.


### PR DESCRIPTION
## Suggestion

As exchanged on [X](https://twitter.com/daviddalbusco/status/1785920309582815527) I would be thrilled if [Juno](https://juno.build) could be listed as one of the deployment options for the starter kit. Given that it provides full control to the developer and offers a hosting solution on Web3 (assets are deployed in a smart contract), I think it would be a great match.

Of course, feel free to ignore this PR if it doesn’t align with your current plans. Thanks for the starter kit, it's a cool initiative!

## Changes

- List Juno in deployement options of the README
- Add hyperlinks to Vercel and Juno